### PR TITLE
Add more about consuming the LLVM-C API and FFI bindings

### DIFF
--- a/llvm.md
+++ b/llvm.md
@@ -45,10 +45,22 @@ Although the LLVM website provides excellent detailed installation instructions,
 
 LLVM does include an experimental code generator for [WebAssembly](/wiki/webassembly). However, since this generator is experimental, it is not built as part of the standard build process. The way you ask for it is by adding -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly to your CMake invocation. Once built, you can generate WebAssembly code using the target triple of "wasm32-unknown-unknown-wasm".
 
+## Using the C API
+
+When you are using the LLVM-C API there are a few important things to take note of.
+
+This API is essentially just an `extern "C"` block which provides C-compatible functions which interact with the C++ ones.
+
+- You may notice how the API exposes types such as `LLVMTypeRef` and `LLVMValueRef` instead of the more complex C++ types. These types simply wrap around one or more LLVM-C++ types and because of this, a function which accepts `LLVMValueRef` may not accept any `LLVMValueRef` because the underlying C++ API expects a more concise type. 
+- Failing to properly manage the C types may lead to unexpected crashes and segfaults
+- Because C isn't capable of tracking the lifetime of certain types like the ExecutionEngine the LLVM-C API requires you to manually de-allocate these objects via the `LLVMDispose` functions. Failing to dispose these objects will lead to memory being leaked.
+    - Various other functions like `LLVMIntrinsicCopyOverloadedName()` may also require you to manually free strings.
+
 ## Bindings
 
-Since LLVM is such a popular platform, there are a number of bindings for popular 
-languages.
+Since LLVM is such a popular platform, there are a number of bindings for popular languages.
+
+Many of these libraries use the LLVM-C API because it is a lot easier to interface with C than C++ which means you should be taking the precautions noted in the paragraph above.
 
 * LLVM's official bindings: [Go](https://github.com/llvm-mirror/llvm/tree/master/bindings/go), [OCaml](https://github.com/llvm-mirror/llvm/tree/master/bindings/ocaml), [Python](https://github.com/llvm-mirror/llvm/tree/master/bindings/python)
-* Unofficial bindings, which are not updated with LLVM and may be out of date: [.NET](https://github.com/microsoft/LLVMSharp), [Haskell](https://hackage.haskell.org/package/llvm-hs), [Rust](https://crates.io/crates/llvm-sys)
+* Unofficial bindings, which are not updated with LLVM and may be out of date: [.NET](https://github.com/microsoft/LLVMSharp), [Haskell](https://hackage.haskell.org/package/llvm-hs), [Rust](https://crates.io/crates/llvm-sys), [Java](https://github.com/bytedeco/javacpp-presets/tree/master/llvm), [Ruby](https://github.com/ruby-llvm/ruby-llvm)


### PR DESCRIPTION
This patch adds a bit more information about what you will meet when working with the C API. It also covers some of the caveats you may face when using FFI bindings for the LLVM.