### PR TITLE
Adding a domain specific GUI challenge link.

### DIFF
--- a/challenges.md
+++ b/challenges.md
@@ -29,3 +29,7 @@ Make sure your programming language is well-rounded by performing some of these 
 
 ## Intermediate
 * Game of Life
+
+## Domain Specific
+* Graphical User Interfaces
+  * [7 GUIs](https://eugenkiss.github.io/7guis/)


### PR DESCRIPTION
I like this page but I think it could use some more meat on it. Adding a section for some domain specific challenges for various different common domains might be useful, especially if they are links to established benchmarks/challenges.

I'll probably have more to contribute as I work through this with my own language.